### PR TITLE
Improve loading UX and skip unnecessary API fetches

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -670,6 +670,33 @@ button {
   font-weight: 500;
 }
 
+/* Loading state for camera count */
+.camera-count.loading .count-number::after {
+  content: '';
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+  border-radius: 8px;
+  background: linear-gradient(110deg, var(--navy) 30%, var(--surface-raised) 50%, var(--navy) 70%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s linear infinite;
+  vertical-align: middle;
+}
+
+.camera-count.loading .count-label::after {
+  content: 'Loading cameras…';
+}
+
+.camera-count.loading .count-label {
+  font-size: 0; /* hide original text */
+}
+
+.camera-count.loading .count-label::after {
+  font-size: 13px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
 /* =============================================================
    Camera List
    ============================================================= */

--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
     <div class="camera-count" id="cameraCount">
       <div class="count-text">
         <span class="count-number" id="countNumber">0</span>
-        <span class="count-label">cameras along route</span>
+        <span class="count-label" id="countLabel">cameras along route</span>
       </div>
       <div class="count-actions">
         <button class="action-btn" id="filterBtn" title="Filter by region" aria-label="Filter by region">

--- a/js/api.js
+++ b/js/api.js
@@ -193,12 +193,19 @@ const API = (() => {
   }
 
   // Fetch regions progressively, calling onRegion as each completes
-  async function fetchProgressive(onRegion) {
-    const fetchers = [
-      fetchAlberta().then(r => { onRegion('AB', r); return r; }),
-      fetchBC().then(r => { onRegion('BC', r); return r; }),
-      fetchWA().then(r => { onRegion('WA', r); return r; }),
+  // If neededRegions is provided (a Set), only fetch those regions
+  async function fetchProgressive(onRegion, neededRegions) {
+    const all = [
+      { key: 'AB', fn: fetchAlberta },
+      { key: 'BC', fn: fetchBC },
+      { key: 'WA', fn: fetchWA },
     ];
+    const toFetch = neededRegions
+      ? all.filter(r => neededRegions.has(r.key))
+      : all;
+    const fetchers = toFetch.map(({ key, fn }) =>
+      fn().then(r => { onRegion(key, r); return r; })
+    );
     await Promise.allSettled(fetchers);
   }
 

--- a/js/app.js
+++ b/js/app.js
@@ -425,16 +425,34 @@ const App = (() => {
     allCameras = [];
     let anyFromCache = false;
 
+    // Show loading state instead of confusing "0 cameras"
+    dom.countNumber.textContent = '';
+    dom.countNumber.classList.add('loading');
+    dom.cameraCount.classList.add('loading');
+
+    // Determine which regions the route passes through
+    const neededRegions = new Set();
+    if (currentWaypoints.length > 0) {
+      for (const wp of currentWaypoints) {
+        neededRegions.add(wp.region);
+      }
+    }
+
     await API.fetchProgressive((region, result) => {
       if (result.fromCache) anyFromCache = true;
       allCameras = allCameras.concat(result.data || []);
       applyFilters();
-    });
+      // Once first results arrive, remove loading state on count
+      dom.countNumber.classList.remove('loading');
+      dom.cameraCount.classList.remove('loading');
+    }, neededRegions.size > 0 ? neededRegions : null);
 
     if (anyFromCache && !navigator.onLine) {
       dom.offlineBanner.classList.add('visible');
     }
     dom.skeletonList.classList.add('hidden');
+    dom.countNumber.classList.remove('loading');
+    dom.cameraCount.classList.remove('loading');
   }
 
   async function refreshCameras() {


### PR DESCRIPTION
- Show shimmer + "Loading cameras…" instead of confusing "0 cameras"
  during initial load
- Only fetch camera data for regions the route actually passes through
  (e.g., Calgary→Kamloops skips WA entirely)
- Remove loading state as soon as first region's results arrive

https://claude.ai/code/session_017vhDAoVtqYUSNQjTsNKNTg