### PR TITLE
Sync map to focused camera on list scroll and flip swap button arrows horizontal

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -740,6 +740,11 @@ button {
   background: rgba(45, 184, 75, 0.06);
 }
 
+.camera-card.focused {
+  border-color: var(--green);
+  box-shadow: 0 0 0 2px rgba(45, 184, 75, 0.2);
+}
+
 .camera-thumb {
   width: 100%;
   aspect-ratio: 16 / 9;

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
       </div>
       <button class="swap-btn" id="swapBtn" title="Swap start and end" aria-label="Swap start and end">
         <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M7 4v16M7 20l-4-4M7 20l4-4M17 20V4M17 4l-4 4M17 4l4 4"/>
+          <path d="M4 7h16M20 7l-4-4M20 7l-4 4M20 17H4M4 17l4-4M4 17l4 4"/>
         </svg>
       </button>
       <div class="route-input" id="toInput" tabindex="0" role="combobox" aria-label="Destination">

--- a/js/app.js
+++ b/js/app.js
@@ -16,6 +16,7 @@ const App = (() => {
   let currentModalCamera = null;
   let sheetExpanded = false; // true when sheet is pulled up (20vh map)
   let _mapInitiatedScroll = false; // true when map viewport change is scrolling the list
+  let _focusedCameraId = null; // the camera card currently centered in the list
   let userLocation = null; // { lat, lon, nearestStop } when geolocation available
 
   const PREFS_KEY = 'tripcams_prefs';
@@ -764,9 +765,18 @@ const App = (() => {
   // ── Scroll Tracking (highlight markers for visible cards) ────
 
   let scrollTrackingObserver = null;
+  let _scrollTrackingHandler = null;
+
+  function isWideLayout() {
+    return window.matchMedia('(min-width: 769px)').matches;
+  }
 
   function setupScrollTracking(cameras) {
     if (scrollTrackingObserver) scrollTrackingObserver.disconnect();
+    if (_scrollTrackingHandler) {
+      dom.cameraList.removeEventListener('scroll', _scrollTrackingHandler);
+      _scrollTrackingHandler = null;
+    }
     if (!('IntersectionObserver' in window)) return;
 
     const visibleIds = new Set();
@@ -794,6 +804,57 @@ const App = (() => {
 
     const cards = dom.cameraList.querySelectorAll('.camera-card');
     cards.forEach(card => scrollTrackingObserver.observe(card));
+
+    // Focused camera tracking: find the card closest to center and sync map
+    let focusDebounce = null;
+    _scrollTrackingHandler = () => {
+      if (_mapInitiatedScroll) return;
+      clearTimeout(focusDebounce);
+      focusDebounce = setTimeout(() => {
+        updateFocusedCamera();
+      }, 150);
+    };
+    dom.cameraList.addEventListener('scroll', _scrollTrackingHandler, { passive: true });
+  }
+
+  function updateFocusedCamera() {
+    if (_mapInitiatedScroll) return;
+    // Only auto-pan on wide layout, or narrow with sheet expanded
+    if (!isWideLayout() && !sheetExpanded) return;
+
+    const listRect = dom.cameraList.getBoundingClientRect();
+    const centerY = listRect.top + listRect.height / 2;
+    const cards = dom.cameraList.querySelectorAll('.camera-card');
+
+    let closestCard = null;
+    let closestDist = Infinity;
+
+    for (const card of cards) {
+      const rect = card.getBoundingClientRect();
+      const cardCenter = rect.top + rect.height / 2;
+      const dist = Math.abs(cardCenter - centerY);
+      if (dist < closestDist) {
+        closestDist = dist;
+        closestCard = card;
+      }
+    }
+
+    if (!closestCard) return;
+    const camId = closestCard.dataset.id;
+    if (camId === _focusedCameraId) return;
+
+    // Update focused state
+    const prevFocused = dom.cameraList.querySelector('.camera-card.focused');
+    if (prevFocused) prevFocused.classList.remove('focused');
+    closestCard.classList.add('focused');
+    _focusedCameraId = camId;
+
+    // Find the camera data and pan map to it
+    const cam = filteredCameras.find(c => c.id === camId);
+    if (cam) {
+      TripMap.highlightMarker(camId);
+      TripMap.panTo(cam.lat, cam.lon, isWideLayout() ? 10 : undefined);
+    }
   }
 
   // ── Map Interactions ─────────────────────────────────────────


### PR DESCRIPTION
When scrolling through the camera list, the map now pans to and highlights
the camera card closest to the center of the list viewport. This works
automatically on wide (desktop) layout and on narrow layout when the sheet
is expanded. A subtle green border/shadow indicates the focused card.

Also changed the swap button SVG arrows from vertical (up/down) to
horizontal (left/right) to better match the side-by-side input layout.

https://claude.ai/code/session_01KeT7AYSUdMZRo4g4W7YqJo