### PR TITLE
Style in-view camera markers as bigger green dots in expanded mode

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -469,6 +469,30 @@ button {
   box-shadow: 0 0 0 4px rgba(45, 184, 75, 0.3), 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
+/* Expanded sheet: dim non-active markers, make active ones pop as green */
+.sheet-expanded .camera-marker {
+  width: 10px !important;
+  height: 10px !important;
+  margin-left: -5px !important;
+  margin-top: -5px !important;
+  opacity: 0.45;
+  border-width: 1.5px;
+  transition: all var(--duration-fast) var(--spring-bounce);
+}
+
+.sheet-expanded .camera-marker.active {
+  width: 20px !important;
+  height: 20px !important;
+  margin-left: -10px !important;
+  margin-top: -10px !important;
+  background: var(--green) !important;
+  opacity: 1;
+  border: 2.5px solid white;
+  transform: none;
+  box-shadow: 0 0 0 5px rgba(45, 184, 75, 0.25), 0 2px 10px rgba(0, 0, 0, 0.3);
+  z-index: 10000 !important;
+}
+
 .marker-cluster {
   background: rgba(45, 184, 75, 0.2) !important;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -133,6 +133,15 @@ const App = (() => {
     registerServiceWorker();
     TripMap.init();
 
+    // On wide layouts, the expanded view is always active
+    function syncExpandedClass() {
+      if (isWideLayout()) {
+        document.body.classList.add('sheet-expanded');
+      }
+    }
+    syncExpandedClass();
+    window.addEventListener('resize', syncExpandedClass);
+
     // Sync camera list when user pans/zooms the map
     TripMap.onViewportChange((visibleIds) => {
       if (visibleIds.length === 0) return;
@@ -944,6 +953,7 @@ const App = (() => {
         mapContainer.style.height = '20vh';
         sheet.style.top = `calc(${headerHeight}px + 20vh)`;
         sheetExpanded = true;
+        document.body.classList.add('sheet-expanded');
         TripMap.invalidateSize();
         // After map resizes, fit to currently visible cards
         setTimeout(() => {
@@ -965,6 +975,7 @@ const App = (() => {
         mapContainer.style.height = '50vh';
         sheet.style.top = `calc(${headerHeight}px + 50vh)`;
         sheetExpanded = false;
+        document.body.classList.remove('sheet-expanded');
         TripMap.invalidateSize();
         setTimeout(() => TripMap.fitToRoute(currentWaypoints), 200);
       }


### PR DESCRIPTION
When the bottom sheet is expanded (or on wide viewports), cameras
currently visible in the list now appear as larger green dots on the
map while other markers shrink and dim. This creates a clear visual
connection between the scrolled list position and the map.

https://claude.ai/code/session_01EAcZxwt9s97B3E63RXj1wH