### PR TITLE
Remove blur and gradient from sheet handle, keep grip floating above

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -635,9 +635,6 @@ button {
   padding: 10px 0 8px;
   cursor: grab;
   border-radius: 20px 20px 0 0;
-  background: linear-gradient(to bottom, var(--navy) 40%, transparent);
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
 }
 
 .sheet-handle-bar {


### PR DESCRIPTION
Removes the backdrop-filter blur and linear-gradient background from .sheet-handle so the grip affordance floats cleanly over the camera list.

https://claude.ai/code/session_01QfH2WzUhzAh2hG9yQpTmjt