### PR TITLE
Fix camera list auto-scrolling on initial load

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -16,6 +16,7 @@ const App = (() => {
   let currentModalCamera = null;
   let sheetRevealed = false; // true once the sheet has been revealed (one-way)
   let _mapInitiatedScroll = false; // true when map viewport change is scrolling the list
+  let _userHasInteractedWithMap = false; // true after first user pan/zoom on the map
   let _focusedCameraId = null; // the camera card currently centered in the list
   let userLocation = null; // { lat, lon, nearestStop } when geolocation available
 
@@ -144,8 +145,18 @@ const App = (() => {
     syncLayout();
     window.addEventListener('resize', syncLayout);
 
+    // Mark when user first interacts with the map (pan/zoom)
+    for (const evt of ['mousedown', 'touchstart', 'wheel']) {
+      dom.mapContainer.addEventListener(evt, () => {
+        _userHasInteractedWithMap = true;
+      }, { once: true, passive: true });
+    }
+
     // Sync camera list when user pans/zooms the map
+    // Skip until user has actually interacted with the map to avoid
+    // auto-scrolling the list away from the top on initial load.
     TripMap.onViewportChange((visibleIds) => {
+      if (!_userHasInteractedWithMap) return;
       if (visibleIds.length === 0) return;
 
       // Find the first camera card (in list/route order) that's in the viewport


### PR DESCRIPTION
## Summary
- On wide viewports, the camera list was auto-scrolled ~217px down on first load, cutting off the first item
- Root cause: `TripMap.onViewportChange` callback fired on the initial `fitToRoute` animation's `moveend` event (after the 1s programmatic-move guard expired), calling `scrollIntoView` on the first visible camera card
- Fix: gate the viewport-change scroll sync behind a `_userHasInteractedWithMap` flag that only becomes true on the first `mousedown`/`touchstart`/`wheel` event on the map container

## Test plan
- [ ] Load the app at a wide viewport (≥769px) — camera list should start at the top, first item fully visible
- [ ] Pan/zoom the map — camera list should scroll to sync with visible markers (viewport sync still works)
- [ ] Mobile layout unaffected (viewport sync is separate from sheet reveal/collapse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)