### PR TITLE
Fix map zoom scaling during camera list scroll on Safari

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -763,6 +763,7 @@ const App = (() => {
 
   let scrollTrackingObserver = null;
   let _scrollTrackingHandler = null;
+  let _hasZoomedForScroll = false;    // true once initial zoom-to-visible is done (one-time)
 
   function isWideLayout() {
     return window.matchMedia('(min-width: 769px)').matches;
@@ -797,10 +798,30 @@ const App = (() => {
     const cards = dom.cameraList.querySelectorAll('.camera-card');
     cards.forEach(card => scrollTrackingObserver.observe(card));
 
-    // Focused camera tracking: find the card closest to center and sync map
+    // Focused camera tracking: find the card closest to center and sync map.
+    // On very first scroll, instantly zoom to fit visible cameras (no animation
+    // to avoid Safari's CSS-transform scaling). After that, only ever pan.
     let focusDebounce = null;
     _scrollTrackingHandler = () => {
       if (_mapInitiatedScroll) return;
+      if (!isWideLayout() && !sheetRevealed) return;
+
+      if (!_hasZoomedForScroll) {
+        _hasZoomedForScroll = true;
+        // One-time: instantly zoom to fit cameras visible in the list
+        const listRect = dom.cameraList.getBoundingClientRect();
+        const visIds = new Set();
+        for (const card of dom.cameraList.querySelectorAll('.camera-card')) {
+          const rect = card.getBoundingClientRect();
+          if (rect.top < listRect.bottom && rect.bottom > listRect.top) {
+            visIds.add(card.dataset.id);
+          }
+        }
+        if (visIds.size > 0) {
+          TripMap.zoomToVisible(visIds);
+        }
+      }
+
       clearTimeout(focusDebounce);
       focusDebounce = setTimeout(() => {
         updateFocusedCamera();
@@ -841,11 +862,11 @@ const App = (() => {
     closestCard.classList.add('focused');
     _focusedCameraId = camId;
 
-    // Find the camera data and pan map to it
+    // Find the camera data and pan map to it (no zoom change)
     const cam = filteredCameras.find(c => c.id === camId);
     if (cam) {
-      TripMap.highlightMarker(camId);
-      TripMap.panTo(cam.lat, cam.lon, isWideLayout() ? 10 : undefined);
+      TripMap.highlightMarkerVisual(camId);
+      TripMap.smoothPanTo(cam.lat, cam.lon);
     }
   }
 

--- a/js/map.js
+++ b/js/map.js
@@ -287,6 +287,48 @@ const TripMap = (() => {
     });
   }
 
+  // Pan without changing zoom — for scroll-tracking so we avoid the
+  // flyTo zoom-out-then-zoom-in arc animation on every camera change.
+  function smoothPanTo(lat, lon) {
+    _markProgrammatic();
+    map.panTo([lat, lon], { animate: true, duration: 0.3 });
+  }
+
+  // Highlight a marker visually (CSS class only) without calling
+  // zoomToShowLayer, which would change zoom during scroll tracking.
+  function highlightMarkerVisual(camId) {
+    if (activeMarkerId && markers.has(activeMarkerId)) {
+      const prev = markers.get(activeMarkerId);
+      const prevEl = prev.getElement?.();
+      if (prevEl) prevEl.classList.remove('active');
+    }
+    activeMarkerId = camId;
+    if (!markers.has(camId)) return;
+    const marker = markers.get(camId);
+    const el = marker.getElement?.();
+    if (el) el.classList.add('active');
+  }
+
+  // Zoom to fit visible cameras instantly (no animation) so Safari
+  // doesn't show a CSS-transform scale effect while the user scrolls.
+  function zoomToVisible(visibleIds) {
+    if (!visibleIds || visibleIds.size === 0) return;
+    const latlngs = [];
+    for (const id of visibleIds) {
+      if (markers.has(id)) {
+        latlngs.push(markers.get(id).getLatLng());
+      }
+    }
+    if (latlngs.length === 0) return;
+    _markProgrammatic();
+    if (latlngs.length === 1) {
+      map.setView(latlngs[0], 10, { animate: false });
+    } else {
+      const bounds = L.latLngBounds(latlngs);
+      map.fitBounds(bounds, { padding: [40, 40], maxZoom: 11, animate: false });
+    }
+  }
+
   function showUserLocation(lat, lon) {
     if (userLocationMarker) {
       userLocationMarker.setLatLng([lat, lon]);
@@ -352,9 +394,12 @@ const TripMap = (() => {
     fitToRoute,
     setMarkers,
     highlightMarker,
+    highlightMarkerVisual,
     highlightVisible,
     fitToVisible,
+    zoomToVisible,
     panTo,
+    smoothPanTo,
     showUserLocation,
     invalidateSize,
     onViewportChange,


### PR DESCRIPTION
## Summary
- Eliminates the jarring zoom-out-then-zoom-in CSS-transform scaling animation that occurred on every camera focus change while scrolling the list, especially noticeable on macOS Safari with trackpad
- On first scroll interaction, instantly zooms map to fit visible cameras (no animation)
- All subsequent scroll-driven map updates only pan along the route without changing zoom level
- Adds `smoothPanTo()`, `highlightMarkerVisual()`, and `zoomToVisible()` to the map API to support animation-free scroll tracking

## Test plan
- [ ] Open on macOS Safari at wide viewport (>769px)
- [ ] Scroll the camera list with trackpad — map should instantly zoom to visible cameras on first scroll, then smoothly pan without any zoom scaling
- [ ] Pause scrolling for several seconds, then resume — should continue panning without re-zooming
- [ ] Verify map marker clicking and modal interactions still work normally
- [ ] Test on narrow/mobile viewport to ensure sheet reveal behavior is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)