### PR TITLE
Highlight focused camera marker on map

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -479,6 +479,15 @@ button {
   box-shadow: 0 0 0 4px rgba(45, 184, 75, 0.3), 0 2px 8px rgba(0, 0, 0, 0.3);
 }
 
+.camera-marker.map-focused {
+  transform: scale(2.2);
+  z-index: 10001 !important;
+  background: white !important;
+  border: 2px solid var(--green);
+  box-shadow: 0 0 0 5px rgba(45, 184, 75, 0.35), 0 0 14px rgba(45, 184, 75, 0.25), 0 2px 8px rgba(0, 0, 0, 0.3);
+  animation: focusedPulse 2s ease-in-out infinite;
+}
+
 /* Expanded sheet: dim non-active markers, make active ones pop as green */
 .sheet-expanded .camera-marker {
   width: 10px !important;
@@ -501,6 +510,25 @@ button {
   transform: none;
   box-shadow: 0 0 0 5px rgba(45, 184, 75, 0.25), 0 2px 10px rgba(0, 0, 0, 0.3);
   z-index: 10000 !important;
+}
+
+/* Focused marker: the camera at the top of the list or hovered in the list */
+.sheet-expanded .camera-marker.map-focused {
+  width: 24px !important;
+  height: 24px !important;
+  margin-left: -12px !important;
+  margin-top: -12px !important;
+  background: white !important;
+  border: 3px solid var(--green);
+  opacity: 1;
+  z-index: 10001 !important;
+  box-shadow: 0 0 0 6px rgba(45, 184, 75, 0.35), 0 0 16px rgba(45, 184, 75, 0.25), 0 2px 10px rgba(0, 0, 0, 0.3);
+  animation: focusedPulse 2s ease-in-out infinite;
+}
+
+@keyframes focusedPulse {
+  0%, 100% { box-shadow: 0 0 0 6px rgba(45, 184, 75, 0.35), 0 0 16px rgba(45, 184, 75, 0.25), 0 2px 10px rgba(0, 0, 0, 0.3); }
+  50% { box-shadow: 0 0 0 10px rgba(45, 184, 75, 0.15), 0 0 24px rgba(45, 184, 75, 0.15), 0 2px 10px rgba(0, 0, 0, 0.3); }
 }
 
 .marker-cluster {

--- a/js/app.js
+++ b/js/app.js
@@ -18,6 +18,8 @@ const App = (() => {
   let _mapInitiatedScroll = false; // true when map viewport change is scrolling the list
   let _userHasInteractedWithMap = false; // true after first user pan/zoom on the map
   let _focusedCameraId = null; // the camera card currently centered in the list
+  let _topCameraId = null; // the camera card at the top of the visible list
+  let _hoveredCameraId = null; // camera card the user is hovering over
   let userLocation = null; // { lat, lon, nearestStop } when geolocation available
 
   const PREFS_KEY = 'tripcams_prefs';
@@ -168,6 +170,9 @@ const App = (() => {
           card.scrollIntoView({ behavior: 'smooth', block: 'start' });
           card.classList.add('highlighted');
           setTimeout(() => card.classList.remove('highlighted'), 2000);
+          // Focus this camera's marker on the map
+          _topCameraId = card.dataset.id;
+          TripMap.focusMarker(card.dataset.id);
           // Clear flag after scroll settles
           setTimeout(() => { _mapInitiatedScroll = false; }, 800);
           break;
@@ -622,6 +627,15 @@ const App = (() => {
         </div>
       `;
       card.addEventListener('click', () => openModal(cam));
+      card.addEventListener('mouseenter', () => {
+        _hoveredCameraId = cam.id;
+        TripMap.focusMarker(cam.id);
+      });
+      card.addEventListener('mouseleave', () => {
+        _hoveredCameraId = null;
+        // Restore focus to the top camera
+        if (_topCameraId) TripMap.focusMarker(_topCameraId);
+      });
     } else {
       card.className = 'camera-card camera-card-disabled';
       card.innerHTML = `
@@ -822,12 +836,42 @@ const App = (() => {
         }
       }
 
+      // Update top camera marker immediately for responsiveness
+      updateTopCamera();
+
       clearTimeout(focusDebounce);
       focusDebounce = setTimeout(() => {
         updateFocusedCamera();
       }, 150);
     };
     dom.cameraList.addEventListener('scroll', _scrollTrackingHandler, { passive: true });
+  }
+
+  // Find the card at the top of the visible scroll area and focus its marker.
+  function updateTopCamera() {
+    const listRect = dom.cameraList.getBoundingClientRect();
+    const topEdge = listRect.top;
+    const cards = dom.cameraList.querySelectorAll('.camera-card');
+
+    let topCard = null;
+    for (const card of cards) {
+      const rect = card.getBoundingClientRect();
+      // First card whose bottom is below the list top (i.e. it's visible)
+      if (rect.bottom > topEdge + 10) {
+        topCard = card;
+        break;
+      }
+    }
+
+    if (!topCard) return;
+    const camId = topCard.dataset.id;
+    if (camId === _topCameraId) return;
+    _topCameraId = camId;
+
+    // Only set map focus if user isn't hovering a card
+    if (!_hoveredCameraId) {
+      TripMap.focusMarker(camId);
+    }
   }
 
   function updateFocusedCamera() {

--- a/js/map.js
+++ b/js/map.js
@@ -177,6 +177,7 @@ const TripMap = (() => {
     markerCluster.clearLayers();
     markers.clear();
     activeMarkerId = null;
+    focusedMarkerId = null;
 
     for (const cam of cameras) {
       if (cam.status === 'inactive') continue;
@@ -229,6 +230,31 @@ const TripMap = (() => {
   }
 
   let activeVisibleIds = new Set();
+  let focusedMarkerId = null;
+
+  // Highlight a single marker as "focused" — the camera at the top of the
+  // scroll list or the one the user is hovering over. Visually distinct from
+  // the regular "active" state that all visible markers share.
+  function focusMarker(camId) {
+    if (camId === focusedMarkerId) return;
+    // Remove previous focus
+    if (focusedMarkerId && markers.has(focusedMarkerId)) {
+      const el = markers.get(focusedMarkerId).getElement?.();
+      if (el) el.classList.remove('map-focused');
+    }
+    focusedMarkerId = camId;
+    if (!camId || !markers.has(camId)) return;
+    const el = markers.get(camId).getElement?.();
+    if (el) el.classList.add('map-focused');
+  }
+
+  function unfocusMarker() {
+    if (focusedMarkerId && markers.has(focusedMarkerId)) {
+      const el = markers.get(focusedMarkerId).getElement?.();
+      if (el) el.classList.remove('map-focused');
+    }
+    focusedMarkerId = null;
+  }
 
   function highlightVisible(visibleIds) {
     // Remove old highlights
@@ -246,6 +272,15 @@ const TripMap = (() => {
       }
     }
     activeVisibleIds = new Set(visibleIds);
+
+    // Re-apply focused marker class — the element may have just become
+    // available after being unclustered by the zoom-to-visible logic.
+    if (focusedMarkerId && markers.has(focusedMarkerId)) {
+      const el = markers.get(focusedMarkerId).getElement?.();
+      if (el && !el.classList.contains('map-focused')) {
+        el.classList.add('map-focused');
+      }
+    }
   }
 
   // Fit map to show the visible cameras with enough context
@@ -396,6 +431,8 @@ const TripMap = (() => {
     highlightMarker,
     highlightMarkerVisual,
     highlightVisible,
+    focusMarker,
+    unfocusMarker,
     fitToVisible,
     zoomToVisible,
     panTo,


### PR DESCRIPTION
## Summary
- Adds a distinct "map-focused" marker style (white fill, green border, pulsing glow ring) for the camera at the top of the scroll list
- Hovering a camera card temporarily shifts the focused marker to that card's camera on the map
- Focus syncs when the map pans and auto-scrolls the list to a new position

## Test plan
- [ ] Scroll the camera list and verify the top card's marker on the map has the distinct white/green pulsing style
- [ ] Hover over different camera cards and confirm the focused marker moves to the hovered card's marker
- [ ] Move mouse off a card and confirm focus returns to the top-of-list camera
- [ ] Pan the map so the list auto-scrolls, verify the scrolled-to card's marker gets focused
- [ ] Test on mobile (narrow viewport) with sheet expanded
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)