### PR TITLE
Mobile UX: auto-reveal camera list, geolocation, and map UI polish

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -579,10 +579,31 @@ button {
   color: var(--text-secondary);
 }
 
+/* Hide Leaflet attribution — keep in DOM for legal compliance, just visually minimal */
+.leaflet-control-attribution {
+  font-size: 0;
+  background: transparent !important;
+  box-shadow: none !important;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.map-container:hover .leaflet-control-attribution,
+.map-container:active .leaflet-control-attribution {
+  font-size: 9px;
+  opacity: 0.5;
+  pointer-events: auto;
+}
+
+.leaflet-control-attribution a {
+  color: inherit !important;
+}
+
 .map-center-btn {
   position: absolute;
-  bottom: 72px;
-  right: 12px;
+  bottom: 64px;
+  right: 16px;
   z-index: 500;
   width: 40px;
   height: 40px;
@@ -604,8 +625,8 @@ button {
 
 .map-toggle {
   position: absolute;
-  bottom: 24px;
-  right: 12px;
+  bottom: 16px;
+  right: 16px;
   z-index: 500;
   width: 40px;
   height: 40px;

--- a/index.html
+++ b/index.html
@@ -65,11 +65,9 @@
   <!-- Map -->
   <div class="map-container" id="mapContainer">
     <div id="map"></div>
-    <button class="map-center-btn" id="centerMapBtn" aria-label="Center map on route">
-      <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <circle cx="12" cy="12" r="10"/>
-        <circle cx="12" cy="12" r="3"/>
-        <path d="M12 2v4M12 18v4M2 12h4M18 12h4"/>
+    <button class="map-center-btn" id="centerMapBtn" aria-label="Center on my location">
+      <svg viewBox="0 0 24 24" width="18" height="18" fill="currentColor">
+        <path d="M2.5 11.4a1.2 1.2 0 0 1-.1-2.2L20 2.3a1.2 1.2 0 0 1 1.6 1.6l-6.9 17.7a1.2 1.2 0 0 1-2.2-.1l-2.7-7.3-7.3-2.8z"/>
       </svg>
     </button>
     <button class="map-toggle" id="mapToggle" aria-label="Toggle satellite view">

--- a/js/app.js
+++ b/js/app.js
@@ -613,6 +613,11 @@ const App = (() => {
 
     renderCameraList(filteredClusters);
     TripMap.setMarkers(cameras, onMarkerClick);
+
+    // Auto-reveal the bottom sheet on narrow viewports once cameras are available
+    if (!sheetRevealed && !isWideLayout() && cameras.length > 0) {
+      revealSheet();
+    }
   }
 
   // ── Camera List Rendering ────────────────────────────────────
@@ -1173,7 +1178,29 @@ const App = (() => {
   }
 
   function centerMap() {
-    if (currentWaypoints.length > 0) {
+    if (userLocation) {
+      snapToCurrentLocation();
+      return;
+    }
+    // Try to get location on demand
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        (pos) => {
+          const { latitude, longitude } = pos.coords;
+          TripMap.showUserLocation(latitude, longitude);
+          const nearest = Cameras.nearestStop(latitude, longitude, allStops);
+          if (nearest) {
+            userLocation = { lat: latitude, lon: longitude, nearestStop: nearest };
+          }
+          snapToCurrentLocation();
+        },
+        () => {
+          // Denied — fall back to fitting route
+          if (currentWaypoints.length > 0) TripMap.fitToRoute(currentWaypoints);
+        },
+        { enableHighAccuracy: true, timeout: 10000 }
+      );
+    } else if (currentWaypoints.length > 0) {
       TripMap.fitToRoute(currentWaypoints);
     }
   }


### PR DESCRIPTION
## Summary
- **Auto-reveal camera list** on narrow viewports when cameras load (no more getting stuck on map-only view)
- **Geolocation button** centers map on user's GPS location and scrolls to nearest camera (falls back to route fit if denied)
- **Navigation arrow icon** replaces the old crosshair/target icon
- **Hide map attribution** by default (fades in on hover for legal compliance)
- **Button spacing** aligned to match bottom sheet inset (16px from right and top of sheet)

Also includes prior work on this branch:
- Camera cluster pagination with travel-direction sorting
- Fluid FLIP modal transitions and shareable camera URLs
- Modal centering and trackpad swipe fixes

## Test plan
- [ ] Load on narrow viewport — camera list should slide up automatically
- [ ] Tap location arrow — should request GPS permission, then center map and scroll to nearest camera
- [ ] Deny location — should fall back to fitting the route
- [ ] Verify attribution is hidden by default, visible on hover
- [ ] Check button spacing on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)