### PR TITLE
Enhance swap button animation with wind-up and bounce effect

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -194,8 +194,7 @@ button {
   background: var(--green);
   color: white;
   flex-shrink: 0;
-  transition: transform var(--duration-fast) var(--spring-bounce),
-              background var(--duration-fast);
+  transition: background var(--duration-fast);
 }
 
 .swap-btn:hover {
@@ -203,7 +202,32 @@ button {
 }
 
 .swap-btn:active {
-  transform: scale(0.85) rotate(180deg);
+  transform: scale(0.92);
+}
+
+.swap-btn.animating {
+  animation: swap-bounce 0.55s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes swap-bounce {
+  0% {
+    transform: scale(1) rotate(0deg);
+  }
+  /* Wind up: pull back slightly in opposite direction */
+  18% {
+    transform: scale(0.88) rotate(-22deg);
+  }
+  /* Main rotation overshoots past 180 */
+  58% {
+    transform: scale(1.04) rotate(198deg);
+  }
+  /* Settle back with a tiny bounce */
+  78% {
+    transform: scale(0.98) rotate(177deg);
+  }
+  100% {
+    transform: scale(1) rotate(180deg);
+  }
 }
 
 /* =============================================================

--- a/js/app.js
+++ b/js/app.js
@@ -424,9 +424,16 @@ const App = (() => {
     if (fromStop) saveHistory(fromStop.id);
     if (toStop) saveHistory(toStop.id);
 
-    // Animate the swap button
-    dom.swapBtn.style.transform = 'scale(0.85) rotate(180deg)';
-    setTimeout(() => { dom.swapBtn.style.transform = ''; }, 300);
+    // Animate the swap button with wind-up and bounce
+    dom.swapBtn.classList.remove('animating');
+    // Force reflow so re-adding the class restarts the animation
+    void dom.swapBtn.offsetWidth;
+    dom.swapBtn.classList.add('animating');
+    dom.swapBtn.addEventListener('animationend', function handler() {
+      dom.swapBtn.classList.remove('animating');
+      dom.swapBtn.style.transform = '';
+      dom.swapBtn.removeEventListener('animationend', handler);
+    });
   }
 
   function updateRouteDisplay() {


### PR DESCRIPTION
## Summary
Improved the swap button animation to use a more polished wind-up and bounce effect instead of a simple instant rotation. The animation now plays as a CSS keyframe animation with easing, providing better visual feedback when swapping routes.

## Key Changes
- **CSS Animation**: Replaced inline transform styles with a dedicated `swap-bounce` keyframe animation that:
  - Winds up with a slight counter-rotation (-22deg) and scale down (0.88)
  - Rotates past the target 180deg to 198deg for an overshoot effect
  - Settles back with a subtle bounce at 177deg before finalizing at 180deg
  - Uses a custom cubic-bezier easing curve for natural motion
  
- **Transition Simplification**: Removed the `transform` transition from `.swap-btn` default state since animation is now handled by keyframes, keeping only the `background` transition for hover effects

- **JavaScript Animation Handling**: Updated the swap button animation logic to:
  - Use CSS class toggling (`animating`) instead of direct style manipulation
  - Force DOM reflow to restart animation on repeated swaps
  - Properly clean up animation state via `animationend` event listener
  - Reset inline styles after animation completes

- **Active State**: Simplified `.swap-btn:active` transform from `scale(0.85) rotate(180deg)` to `scale(0.92)` for a subtle press feedback

## Implementation Details
The animation uses a 0.55s duration with a spring-like cubic-bezier curve `(0.22, 1, 0.36, 1)` to create a bouncy, natural feel. The reflow technique (`void dom.swapBtn.offsetWidth`) ensures the animation restarts even when triggered consecutively on the same element.

https://claude.ai/code/session_01WbAeZRb4H6M9FvqnsHqMtJ