### PR TITLE
Fix map control button alignment and positioning

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -398,14 +398,17 @@ button {
   border: 1px solid var(--border) !important;
   width: 40px !important;
   height: 40px !important;
-  line-height: 40px !important;
+  line-height: 1 !important;
   font-size: 18px !important;
   border-radius: 12px !important;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
 }
 
 .leaflet-control-zoom a:first-child {
   border-radius: 12px 12px 4px 4px !important;
-  margin-bottom: 2px !important;
+  margin-bottom: 1px !important;
 }
 
 .leaflet-control-zoom a:last-child {
@@ -602,7 +605,7 @@ button {
 
 .map-center-btn {
   position: absolute;
-  bottom: 224px;
+  bottom: 180px;
   right: 16px;
   z-index: 500;
   width: 40px;
@@ -621,7 +624,7 @@ button {
 }
 
 .sheet-expanded .map-center-btn {
-  bottom: 64px;
+  bottom: 60px;
 }
 
 .map-center-btn:active {
@@ -630,7 +633,7 @@ button {
 
 .map-toggle {
   position: absolute;
-  bottom: 176px;
+  bottom: 136px;
   right: 16px;
   z-index: 500;
   width: 40px;
@@ -651,6 +654,7 @@ button {
 .sheet-expanded .map-toggle {
   bottom: 16px;
 }
+
 
 .map-toggle:active {
   transform: scale(0.9);
@@ -1385,7 +1389,7 @@ button {
     width: 50%;
   }
 
-  .map-center-btn { bottom: 64px; }
+  .map-center-btn { bottom: 60px; }
   .map-toggle { bottom: 16px; }
 
   .sheet,


### PR DESCRIPTION
## Summary
Improved the alignment and positioning of map control buttons by switching from line-height-based centering to flexbox layout, and adjusted button positioning values for better visual consistency.

## Key Changes
- **Button centering**: Changed `.leaflet-control-zoom a` from `line-height: 40px` to `line-height: 1` and added flexbox properties (`display: flex`, `align-items: center`, `justify-content: center`) for more reliable vertical and horizontal centering
- **Button spacing**: Reduced margin between zoom buttons from `2px` to `1px` for tighter spacing
- **Map center button positioning**: 
  - Adjusted default position from `bottom: 224px` to `bottom: 180px`
  - Updated expanded sheet position from `bottom: 64px` to `bottom: 60px`
  - Updated responsive breakpoint from `bottom: 64px` to `bottom: 60px`
- **Map toggle button positioning**: Adjusted default position from `bottom: 176px` to `bottom: 136px`

## Implementation Details
The switch to flexbox for button centering is more robust than relying on line-height, as it properly handles content of varying sizes and prevents potential text alignment issues. The positioning adjustments appear to be refinements to the button layout hierarchy on the map interface.

https://claude.ai/code/session_0189hcUk68c7q2D8PGUFDVfQ