### PR TITLE
Simplify marker sizing to 3 states based on route stroke

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -485,80 +485,54 @@ button {
   right: 8px !important;
 }
 
-/* ---- Camera markers & clusters: transit-style nodes on the route ---- */
+/* ---- Camera markers & clusters: transit-style nodes on the route ----
+   Sizes are proportional to the route stroke width (5px visual weight).
+   Default  = 30% bigger  →  10px  (stroke + 30% padding)
+   In-view  = 50% bigger  →  12px  (.active)
+   Hovered  = 75% bigger  →  14px  (.map-hovered)
+   Uses width/height (not transform) because Leaflet uses transform for positioning.
+*/
 .camera-marker,
 .marker-cluster {
+  --sz: 10px;
   background: var(--green);
   border: 2px solid white;
   border-radius: 50%;
-  width: 12px !important;
-  height: 12px !important;
-  margin-left: -6px !important;
-  margin-top: -6px !important;
-  box-shadow: 0 0 0 1px var(--green-glow), 0 1px 3px rgba(0, 0, 0, 0.25);
+  width: var(--sz) !important;
+  height: var(--sz) !important;
+  margin-left: calc(var(--sz) / -2) !important;
+  margin-top: calc(var(--sz) / -2) !important;
+  box-shadow: 0 0 0 1px var(--green-glow), 0 1px 2px rgba(0, 0, 0, 0.2);
   opacity: 0.85;
-}
-
-.camera-marker {
   transition: width var(--duration) var(--spring-bounce),
               height var(--duration) var(--spring-bounce),
               margin var(--duration) var(--spring-bounce),
               opacity var(--duration-fast) var(--spring-bounce),
-              transform var(--duration-fast) var(--spring-bounce),
-              box-shadow var(--duration) var(--spring-bounce),
-              border-width var(--duration) var(--spring-bounce);
+              box-shadow var(--duration) var(--spring-bounce);
 }
 
-.camera-marker:hover {
-  opacity: 1;
-  transform: scale(1.15);
-}
-
-/* Visible in the camera list */
-.camera-marker.active {
+/* In-view — camera visible in the list */
+.camera-marker.active,
+.marker-cluster.active {
+  --sz: 12px;
   opacity: 1;
   z-index: 10000 !important;
 }
 
-/* Hovered from the list */
-.camera-marker.map-hovered {
-  opacity: 1;
-  transform: scale(1.15);
-  z-index: 10002 !important;
-}
-
-/* Focused — top of scroll list (larger node with glow).
-   Combined selector ensures it overrides .sheet-expanded .camera-marker too. */
-.camera-marker.map-focused,
-.sheet-expanded .camera-marker.map-focused {
-  width: 18px !important;
-  height: 18px !important;
-  margin-left: -9px !important;
-  margin-top: -9px !important;
-  border: 2.5px solid white;
-  opacity: 1;
-  z-index: 10001 !important;
-  box-shadow: 0 0 0 4px var(--green-glow), 0 2px 6px rgba(0, 0, 0, 0.25);
-}
-
-/* ---- Sheet expanded overrides ---- */
-.sheet-expanded .camera-marker,
-.sheet-expanded .marker-cluster {
-  width: 8px !important;
-  height: 8px !important;
-  margin-left: -4px !important;
-  margin-top: -4px !important;
-  opacity: 0.45;
-  border-width: 1.5px;
-}
-
-.sheet-expanded .camera-marker.active {
-  opacity: 0.8;
-}
-
-.sheet-expanded .camera-marker.map-hovered {
+/* Hovered from the list card */
+.camera-marker.map-hovered,
+.marker-cluster.map-hovered {
+  --sz: 14px;
   opacity: 1;
   z-index: 10002 !important;
+  box-shadow: 0 0 0 3px var(--green-glow), 0 2px 4px rgba(0, 0, 0, 0.25);
+}
+
+/* Mouse hover directly on map node */
+.camera-marker:hover,
+.marker-cluster:hover {
+  --sz: 14px;
+  opacity: 1;
 }
 
 .popup-content {

--- a/js/app.js
+++ b/js/app.js
@@ -167,9 +167,7 @@ const App = (() => {
           card.scrollIntoView({ behavior: 'smooth', block: 'center' });
           card.classList.add('highlighted');
           setTimeout(() => card.classList.remove('highlighted'), 2000);
-          // Focus this camera's marker on the map
           _topCameraId = card.dataset.id;
-          TripMap.focusMarker(card.dataset.id);
           // Clear flag after scroll settles
           setTimeout(() => { _mapInitiatedScroll = false; }, 800);
           break;
@@ -680,13 +678,11 @@ const App = (() => {
       card.addEventListener('click', () => openModal(cam, null, card));
       card.addEventListener('mouseenter', () => {
         _hoveredCameraId = cam.id;
-        TripMap.focusMarker(cam.id);
         TripMap.hoverMarker(cam.id);
       });
       card.addEventListener('mouseleave', () => {
         _hoveredCameraId = null;
         TripMap.unhoverMarker();
-        if (_topCameraId) TripMap.focusMarker(_topCameraId);
       });
     } else {
       card.className = 'camera-card camera-card-disabled';
@@ -864,13 +860,11 @@ const App = (() => {
     // ── Hover / focus map sync ──
     card.addEventListener('mouseenter', () => {
       _hoveredCameraId = cams[currentPage].id;
-      TripMap.focusMarker(cams[currentPage].id);
       TripMap.hoverMarker(cams[currentPage].id);
     });
     card.addEventListener('mouseleave', () => {
       _hoveredCameraId = null;
       TripMap.unhoverMarker();
-      if (_topCameraId) TripMap.focusMarker(_topCameraId);
     });
 
     return card;
@@ -1115,10 +1109,6 @@ const App = (() => {
     if (camId === _topCameraId) return;
     _topCameraId = camId;
 
-    // Only set map focus if user isn't hovering a card
-    if (!_hoveredCameraId) {
-      TripMap.focusMarker(camId);
-    }
   }
 
   function updateFocusedCamera() {
@@ -1258,7 +1248,6 @@ const App = (() => {
           if (cam) {
             TripMap.panTo(cam.lat, cam.lon, 10);
             TripMap.highlightMarkerVisual(topCamId);
-            TripMap.focusMarker(topCamId);
           }
         } else {
           // Fallback: fit to all visible cameras

--- a/js/map.js
+++ b/js/map.js
@@ -65,7 +65,7 @@ const TripMap = (() => {
         return L.divIcon({
           html: '',
           className: 'marker-cluster',
-          iconSize: L.point(8, 8),
+          iconSize: L.point(10, 10),
         });
       },
     });
@@ -307,7 +307,7 @@ const TripMap = (() => {
   let _cameraIcon = null;
   function getCameraIcon() {
     if (!_cameraIcon) {
-      _cameraIcon = L.divIcon({ className: 'camera-marker', iconSize: [12, 12] });
+      _cameraIcon = L.divIcon({ className: 'camera-marker', iconSize: [10, 10] });
     }
     return _cameraIcon;
   }
@@ -316,7 +316,7 @@ const TripMap = (() => {
     markerCluster.clearLayers();
     markers.clear();
     activeMarkerId = null;
-    focusedMarkerId = null;
+    hoveredMarkerId = null;
 
     for (const cam of cameras) {
       if (cam.status === 'inactive') continue;
@@ -350,12 +350,10 @@ const TripMap = (() => {
 
   function highlightMarker(camId) {
     // Remove previous highlight
-    if (activeMarkerId && markers.has(activeMarkerId)) {
-      const prev = markers.get(activeMarkerId);
-      const prevEl = prev.getElement?.();
+    if (activeMarkerId) {
+      const prevEl = _getVisibleEl(activeMarkerId);
       if (prevEl) prevEl.classList.remove('active');
     }
-
     activeMarkerId = camId;
     if (!markers.has(camId)) return;
 
@@ -363,82 +361,54 @@ const TripMap = (() => {
     // Ensure the marker is visible (uncluster if needed)
     _markProgrammatic();
     markerCluster.zoomToShowLayer(marker, () => {
-      const el = marker.getElement?.();
+      const el = _getVisibleEl(camId);
       if (el) el.classList.add('active');
     });
   }
 
   let activeVisibleIds = new Set();
-  let focusedMarkerId = null;
-
-  // Highlight a single marker as "focused" — the camera at the top of the
-  // scroll list or the one the user is hovering over. Visually distinct from
-  // the regular "active" state that all visible markers share.
-  function focusMarker(camId) {
-    if (camId === focusedMarkerId) return;
-    // Remove previous focus
-    if (focusedMarkerId && markers.has(focusedMarkerId)) {
-      const el = markers.get(focusedMarkerId).getElement?.();
-      if (el) el.classList.remove('map-focused');
-    }
-    focusedMarkerId = camId;
-    if (!camId || !markers.has(camId)) return;
-    const el = markers.get(camId).getElement?.();
-    if (el) el.classList.add('map-focused');
-  }
-
-  function unfocusMarker() {
-    if (focusedMarkerId && markers.has(focusedMarkerId)) {
-      const el = markers.get(focusedMarkerId).getElement?.();
-      if (el) el.classList.remove('map-focused');
-    }
-    focusedMarkerId = null;
-  }
-
   let hoveredMarkerId = null;
+
+  // Get the visible DOM element for a marker — if the marker is inside a
+  // cluster, return the cluster's icon element instead.
+  function _getVisibleEl(camId) {
+    if (!markers.has(camId)) return null;
+    const marker = markers.get(camId);
+    const parent = markerCluster.getVisibleParent(marker);
+    if (!parent) return null;
+    return parent.getElement?.() ?? null;
+  }
 
   function hoverMarker(camId) {
     if (camId === hoveredMarkerId) return;
     unhoverMarker();
     hoveredMarkerId = camId;
-    if (!camId || !markers.has(camId)) return;
-    const el = markers.get(camId).getElement?.();
+    const el = _getVisibleEl(camId);
     if (el) el.classList.add('map-hovered');
   }
 
   function unhoverMarker() {
-    if (hoveredMarkerId && markers.has(hoveredMarkerId)) {
-      const el = markers.get(hoveredMarkerId).getElement?.();
+    if (hoveredMarkerId) {
+      const el = _getVisibleEl(hoveredMarkerId);
       if (el) el.classList.remove('map-hovered');
     }
     hoveredMarkerId = null;
   }
 
   function highlightVisible(visibleIds) {
-    // Remove old highlights
+    // Remove old highlights from markers and their parent clusters
     for (const id of activeVisibleIds) {
-      if (!visibleIds.has(id) && markers.has(id)) {
-        const el = markers.get(id).getElement?.();
+      if (!visibleIds.has(id)) {
+        const el = _getVisibleEl(id);
         if (el) el.classList.remove('active');
       }
     }
-    // Add new highlights
+    // Add new highlights — applies to cluster icon if marker is clustered
     for (const id of visibleIds) {
-      if (markers.has(id)) {
-        const el = markers.get(id).getElement?.();
-        if (el) el.classList.add('active');
-      }
+      const el = _getVisibleEl(id);
+      if (el) el.classList.add('active');
     }
     activeVisibleIds = new Set(visibleIds);
-
-    // Re-apply focused marker class — the element may have just become
-    // available after being unclustered by the zoom-to-visible logic.
-    if (focusedMarkerId && markers.has(focusedMarkerId)) {
-      const el = markers.get(focusedMarkerId).getElement?.();
-      if (el && !el.classList.contains('map-focused')) {
-        el.classList.add('map-focused');
-      }
-    }
   }
 
   // Fit map to show the visible cameras with enough context
@@ -490,15 +460,12 @@ const TripMap = (() => {
   // Highlight a marker visually (CSS class only) without calling
   // zoomToShowLayer, which would change zoom during scroll tracking.
   function highlightMarkerVisual(camId) {
-    if (activeMarkerId && markers.has(activeMarkerId)) {
-      const prev = markers.get(activeMarkerId);
-      const prevEl = prev.getElement?.();
+    if (activeMarkerId) {
+      const prevEl = _getVisibleEl(activeMarkerId);
       if (prevEl) prevEl.classList.remove('active');
     }
     activeMarkerId = camId;
-    if (!markers.has(camId)) return;
-    const marker = markers.get(camId);
-    const el = marker.getElement?.();
+    const el = _getVisibleEl(camId);
     if (el) el.classList.add('active');
   }
 
@@ -589,8 +556,6 @@ const TripMap = (() => {
     highlightMarker,
     highlightMarkerVisual,
     highlightVisible,
-    focusMarker,
-    unfocusMarker,
     hoverMarker,
     unhoverMarker,
     fitToVisible,


### PR DESCRIPTION
## Changes

- **CSS**: Refactored camera markers and clusters to use CSS custom property (`--sz`) for cleaner sizing
  - Default: 10px (30% bigger than 5px stroke)
  - Active (in-view): 12px (50% bigger)
  - Hovered/map-hovered: 14px (75% bigger)
  - Removed separate `.sheet-expanded` states and `.map-focused` class
  - Used width/height instead of transform for Leaflet positioning compatibility

- **JavaScript**: Removed focus marker functionality
  - Deleted `focusMarker()` and `unfocusMarker()` functions from map.js
  - Removed all `TripMap.focusMarker()` calls from app.js
  - Simplified marker state management by consolidating focus/hover logic
  - Updated `getCameraIcon()` size from 12px to 10px
  - Renamed internal `focusedMarkerId` to `hoveredMarkerId` for clarity
  - Added `_getVisibleEl()` helper to handle clustered markers correctly

- **Result**: 72 fewer lines, cleaner marker state transitions, and more maintainable code