### PR TITLE
Adjust bottom sheet padding and handle height calculations

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -699,7 +699,7 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 0;
+  padding: 12px 0;
   cursor: grab;
   border-radius: 20px 20px 0 0;
   opacity: 0;
@@ -730,7 +730,7 @@ button {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-  padding: 24px 12px 0;
+  padding: 28px 12px 0;
   padding-bottom: calc(var(--safe-bottom) + 20px);
   scrollbar-width: none;
 }
@@ -766,7 +766,7 @@ button {
   left: 0;
   right: 0;
   /* Centre vertically between handle bar and first camera card.
-     Peeking sheet = 120px, handle = ~24px, so visible list area ≈ 96px.
+     Peeking sheet = 120px, handle = ~28px, so visible list area ≈ 92px.
      Place spinner at the midpoint of that visible area. */
   top: 0;
   height: 80px !important;


### PR DESCRIPTION
## Summary
This PR adjusts the vertical spacing and padding of the bottom sheet component to improve visual layout and accommodate a taller drag handle.

## Key Changes
- Increased drag handle padding from `10px` to `12px` (2px increase)
- Increased bottom sheet content padding-top from `24px` to `28px` (4px increase)
- Updated comment to reflect new handle height (~28px instead of ~24px) and recalculated visible list area (≈92px instead of ≈96px)

## Implementation Details
These changes maintain the visual balance of the bottom sheet component by:
- Providing more breathing room around the drag handle
- Adjusting the content area padding to account for the larger handle
- Updating the spinner positioning calculation comment to reflect the new dimensions

https://claude.ai/code/session_01UeAamxuvM9wPTcxUgpNdxT