### PR TITLE
Fix modal layout measurement in Safari with double rAF

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1590,10 +1590,11 @@ const App = (() => {
       );
       _flipClone = clone;
 
-      // Force layout so the modal is at its final position for measurement
-      void dom.modal.offsetHeight;
+      // Force overlay + modal layout so flex centering is resolved (Safari needs this)
+      void dom.modalOverlay.offsetHeight;
 
-      requestAnimationFrame(() => {
+      // Double-rAF ensures Safari has fully resolved the flex layout before measuring
+      requestAnimationFrame(() => { requestAnimationFrame(() => {
         const modalImgContainer = dom.modal.querySelector('.modal-image-container');
         const modalImg = modalImgContainer.querySelector('.cluster-slide img, :scope > img');
         const lastRect = modalImgContainer.getBoundingClientRect();
@@ -1635,7 +1636,7 @@ const App = (() => {
           cleanup();
         }, { once: false });
         setTimeout(cleanup, 600);
-      });
+      }); });
     } else {
       dom.modalOverlay.classList.add('active');
       document.body.style.overflow = 'hidden';


### PR DESCRIPTION
## Summary
Fixed modal positioning and measurement issues in Safari by ensuring flex layout is fully resolved before taking measurements.

## Key Changes
- Changed layout force trigger from `dom.modal.offsetHeight` to `dom.modalOverlay.offsetHeight` to force layout on the overlay container
- Implemented double `requestAnimationFrame` pattern to ensure Safari has fully resolved flex centering before measuring modal dimensions
- Updated comments to clarify the Safari-specific layout resolution requirements

## Implementation Details
The fix addresses a Safari-specific issue where flex centering layout wasn't fully resolved before the modal measurements were taken. By:
1. Triggering layout on the overlay element (which contains the flex container)
2. Using nested `requestAnimationFrame` calls to defer measurement until after two animation frames, giving Safari sufficient time to resolve the flex layout

This ensures consistent modal positioning and animation behavior across browsers, particularly in Safari where the timing of layout resolution differs from other browsers.

https://claude.ai/code/session_014GpqGGAbSuS6WLcKATd6oq