### PR TITLE
Improve load times and poor cell signal performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
   <link rel="dns-prefetch" href="https://www.drivebc.ca">
   <link rel="dns-prefetch" href="https://router.project-osrm.org">
   <link rel="dns-prefetch" href="https://photon.komoot.io">
+  <link rel="preload" href="data/route.json" as="fetch" crossorigin>
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
     integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.5.3/dist/MarkerCluster.css" crossorigin="">

--- a/js/api.js
+++ b/js/api.js
@@ -297,11 +297,22 @@ const API = (() => {
     }
   }
 
-  function getTimeouts() {
+  function isSlowConnection() {
+    if (!navigator.onLine) return true;
     const conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
-    const slow = conn && (conn.saveData || ['slow-2g', '2g', '3g'].includes(conn.effectiveType));
+    if (!conn) return false;
+    if (conn.saveData) return true;
+    if (conn.effectiveType && ['slow-2g', '2g', '3g'].includes(conn.effectiveType)) return true;
+    return false;
+  }
+
+  function getTimeouts() {
+    const slow = isSlowConnection();
     return { direct: slow ? 20000 : 10000, proxy: slow ? 25000 : 15000 };
   }
+
+  // Track which proxy indices have failed this session to skip them on subsequent calls
+  const _failedProxies = new Set();
 
   async function fetchDirect(url, options = {}) {
     const controller = new AbortController();
@@ -338,13 +349,18 @@ const API = (() => {
     }
   }
 
-  // Try direct, then each proxy in order
+  // Try direct, then each proxy in order (skipping proxies that failed this session)
   async function fetchWithRetry(url) {
     try {
       return await fetchDirect(url);
     } catch (e) {
-      for (const proxyFn of CORS_PROXIES) {
-        try { return await fetchViaProxy(url, proxyFn); } catch (_) { /* next */ }
+      for (let i = 0; i < CORS_PROXIES.length; i++) {
+        if (_failedProxies.has(i)) continue;
+        try {
+          return await fetchViaProxy(url, CORS_PROXIES[i]);
+        } catch (_) {
+          _failedProxies.add(i);
+        }
       }
       throw e;
     }
@@ -366,23 +382,15 @@ const API = (() => {
 
   // ── Region fetching ────────────────────────────────────────────
 
-  // Get the normalizer function for a region
+  // Normalizers that need the region code passed through
+  const REGION_NORMALIZERS = { normalizeIBI: true, normalizeArcGIS: true };
+
   function getNormalizer(region) {
     const entry = CAMERA_REGISTRY[region];
     if (!entry) return (d) => [];
-    const normName = entry.norm;
-    // normalizeIBI is the generic IBI 511 normalizer that takes a region code
-    if (normName === 'normalizeIBI') return (d) => Cameras.normalizeIBI(d, region);
-    if (normName === 'normalizeAlberta') return Cameras.normalizeAlberta;
-    if (normName === 'normalizeBC') return Cameras.normalizeBC;
-    if (normName === 'normalizeWA') return Cameras.normalizeWA;
-    if (normName === 'normalizeQC') return Cameras.normalizeQC;
-    if (normName === 'normalizeMD') return Cameras.normalizeMD;
-    if (normName === 'normalizeOH') return Cameras.normalizeOH;
-    if (normName === 'normalizeND') return Cameras.normalizeND;
-    if (normName === 'normalizeArcGIS') return (d) => Cameras.normalizeArcGIS(d, region);
-    if (normName === 'normalizeCA') return Cameras.normalizeCA;
-    return (d) => [];
+    const fn = Cameras[entry.norm];
+    if (!fn) return (d) => [];
+    return REGION_NORMALIZERS[entry.norm] ? (d) => fn(d, region) : fn;
   }
 
   // Generic fetch for a region: stale-while-revalidate pattern
@@ -583,7 +591,7 @@ const API = (() => {
 
     if (regions.length === 0) return;
 
-    const BATCH_SIZE = 8;
+    const BATCH_SIZE = isSlowConnection() ? 3 : 8;
     for (let i = 0; i < regions.length; i += BATCH_SIZE) {
       const batch = regions.slice(i, i + BATCH_SIZE);
       const fetchers = batch.map(key =>
@@ -927,6 +935,7 @@ const API = (() => {
     setRouteGeometry,
     fetchIncidents,
     hasIncidentRegion,
+    isSlowConnection,
     CAMERA_REGISTRY,
   };
 })();

--- a/js/app.js
+++ b/js/app.js
@@ -154,15 +154,8 @@ const App = (() => {
     return entry;
   }
 
-  // Connection quality detection
   function isSlowConnection() {
-    if (!navigator.onLine) return true;
-    const conn = navigator.connection || navigator.mozConnection || navigator.webkitConnection;
-    if (!conn) return false;
-    // saveData flag or effective type is slow
-    if (conn.saveData) return true;
-    if (conn.effectiveType && ['slow-2g', '2g', '3g'].includes(conn.effectiveType)) return true;
-    return false;
+    return API.isSlowConnection();
   }
 
   // DOM refs
@@ -1054,17 +1047,17 @@ const App = (() => {
       ? Cameras.filterByCorridor(allCameras, reducedPath, buffer)
       : allCameras;
 
+    // Quick check: skip expensive sort+render if camera set hasn't changed
+    const idSet = cameras.map(c => c.id).join(',');
+    if (idSet === _lastFilteredIds) {
+      return; // Same cameras — no sort or DOM work needed
+    }
+
     // Sort by route order
     if (reducedPath.length > 0) {
       cameras = Cameras.sortByRoute(cameras, reducedPath);
     }
-
-    // Skip re-render if the camera list hasn't changed
-    const newIds = cameras.map(c => c.id).join(',');
-    if (newIds === _lastFilteredIds) {
-      return; // Same cameras in same order — no DOM work needed
-    }
-    _lastFilteredIds = newIds;
+    _lastFilteredIds = idSet;
 
     filteredCameras = cameras;
 
@@ -1456,10 +1449,12 @@ const App = (() => {
     return src + sep + '_t=' + bucket;
   }
 
+  let _lazyObserver = null;
   function setupLazyLoading() {
+    if (_lazyObserver) _lazyObserver.disconnect();
     const images = dom.cameraList.querySelectorAll('img[data-src]');
     if ('IntersectionObserver' in window) {
-      const observer = new IntersectionObserver((entries) => {
+      const observer = _lazyObserver = new IntersectionObserver((entries) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
             const img = entry.target;

--- a/js/cameras.js
+++ b/js/cameras.js
@@ -91,45 +91,8 @@ const Cameras = (() => {
     return bestIdx + bestT;
   }
 
-  // Normalize Alberta 511 camera data
   function normalizeAlberta(data) {
-    if (!Array.isArray(data)) return [];
-    const cameras = [];
-    for (const cam of data) {
-      if (!cam.Latitude || !cam.Longitude) continue;
-      const views = cam.Views || [];
-      for (const view of views) {
-        cameras.push({
-          id: `ab-${cam.Id}-${view.Id || 0}`,
-          name: cam.Location || 'Unknown',
-          highway: cam.Roadway || '',
-          region: 'AB',
-          lat: cam.Latitude,
-          lon: cam.Longitude,
-          imageUrl: view.Url || '',
-          status: (view.Status || '').toLowerCase() === 'disabled' ? 'inactive' : 'active',
-          direction: cam.Direction || view.Description || '',
-          lastUpdated: view.LastUpdated || null,
-          temperature: cam.Temperature ?? null,
-        });
-      }
-      if (views.length === 0) {
-        cameras.push({
-          id: `ab-${cam.Id}`,
-          name: cam.Location || 'Unknown',
-          highway: cam.Roadway || '',
-          region: 'AB',
-          lat: cam.Latitude,
-          lon: cam.Longitude,
-          imageUrl: '',
-          status: 'inactive',
-          direction: cam.Direction || '',
-          lastUpdated: null,
-          temperature: cam.Temperature ?? null,
-        });
-      }
-    }
-    return cameras;
+    return normalizeIBI(data, 'AB');
   }
 
   // Normalize DriveBC camera data

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
    sw.js — Service Worker with tiered caching strategies
    ============================================================= */
 
-const CACHE_NAME = 'tripcams-v35';
+const CACHE_NAME = 'tripcams-v36';
 const STATIC_ASSETS = [
   './',
   'index.html',
@@ -12,6 +12,7 @@ const STATIC_ASSETS = [
   'js/cameras.js',
   'js/map.js',
   'data/route.json',
+  'data/region-bounds.json',
   'img/placeholder.svg',
   'manifest.json',
 ];
@@ -28,6 +29,8 @@ const API_CACHE = 'tripcams-api-v1';
 const IMAGE_CACHE = 'tripcams-images-v1';
 const TILE_CACHE = 'tripcams-tiles-v1';
 const API_CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+const ROUTING_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours (road geometry rarely changes)
+const SW_FETCH_TIMEOUT = 15000; // 15s timeout for SW-level fetches
 const IMAGE_CACHE_DURATION = 30 * 60 * 1000; // 30 minutes (was 2 — too short for road trips)
 const TILE_CACHE_DURATION = 24 * 60 * 60 * 1000; // 24 hours (map tiles rarely change)
 const IMAGE_CACHE_LIMIT = 200;
@@ -38,10 +41,8 @@ self.addEventListener('install', (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then(async (cache) => {
       await cache.addAll(STATIC_ASSETS);
-      // CDN assets — best effort
-      for (const url of CDN_ASSETS) {
-        try { await cache.add(url); } catch (e) { /* ok */ }
-      }
+      // CDN assets — best effort, fetch in parallel
+      await Promise.allSettled(CDN_ASSETS.map(url => cache.add(url)));
     })
   );
 });
@@ -70,15 +71,16 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   const url = new URL(event.request.url);
 
-  // API requests (via CORS proxy or direct to camera APIs)
-  if (isApiRequest(url)) {
-    event.respondWith(networkFirstWithCache(event.request, API_CACHE, API_CACHE_DURATION));
+  // Camera images — check before API requests so image hosts (e.g. images.drivebc.ca)
+  // get cache-first treatment instead of network-first
+  if (isCameraImage(url)) {
+    event.respondWith(cacheFirstWithExpiry(event.request, IMAGE_CACHE, IMAGE_CACHE_DURATION));
     return;
   }
 
-  // Camera images
-  if (isCameraImage(url)) {
-    event.respondWith(cacheFirstWithExpiry(event.request, IMAGE_CACHE, IMAGE_CACHE_DURATION));
+  // API requests (via CORS proxy or direct to camera APIs)
+  if (isApiRequest(url)) {
+    event.respondWith(networkFirstWithCache(event.request, API_CACHE, API_CACHE_DURATION));
     return;
   }
 
@@ -90,7 +92,7 @@ self.addEventListener('fetch', (event) => {
 
   // OSRM routing API — cache for 24 hours (road geometry doesn't change often)
   if (isRoutingApi(url)) {
-    event.respondWith(networkFirstWithCache(event.request, API_CACHE, API_CACHE_DURATION));
+    event.respondWith(networkFirstWithCache(event.request, API_CACHE, ROUTING_CACHE_DURATION));
     return;
   }
 
@@ -102,7 +104,10 @@ self.addEventListener('fetch', (event) => {
 
 async function networkFirstWithCache(request, cacheName, maxAge) {
   try {
-    const response = await fetch(request);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), SW_FETCH_TIMEOUT);
+    const response = await fetch(request, { signal: controller.signal });
+    clearTimeout(timeout);
     if (response.ok) {
       const cache = await caches.open(cacheName);
       const headers = new Headers(response.headers);


### PR DESCRIPTION
- SW: Fix OSRM cache TTL from 5min to 24h to match app-level cache
- SW: Add 15s fetch timeout to prevent stalled responses on slow cell
- SW: Check camera images before API requests so DriveBC images get
  cache-first (30min) instead of network-first (5min) treatment
- SW: Precache CDN assets in parallel instead of sequentially
- SW: Add region-bounds.json to precached static assets
- SW: Bump cache version to v36
- Preload data/route.json (critical-path resource) via link hint
- Reduce API fetch batch size from 8 to 3 on slow connections
- Add proxy circuit-breaker: skip CORS proxies that failed this session
- Share isSlowConnection() from api.js to avoid duplicate logic in app.js
- Fix IntersectionObserver leak: disconnect previous observer on re-render
- Move camera ID dedup check before expensive sortByRoute in applyFilters
- Simplify getNormalizer to data-driven object lookup
- Deduplicate normalizeAlberta by delegating to normalizeIBI

https://claude.ai/code/session_01K71BrYNSLKPixCHAGupBXY