### PR TITLE
Improve Service Worker update handling for Safari/WebKit

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2462,6 +2462,7 @@ const App = (() => {
   // ── Service Worker ───────────────────────────────────────────
 
   let _waitingSW = null;
+  let _updateFallbackTimer = null;
 
   function registerServiceWorker() {
     if (!('serviceWorker' in navigator)) return;
@@ -2469,6 +2470,19 @@ const App = (() => {
     navigator.serviceWorker.register('sw.js').then(reg => {
       // If a new SW is already waiting (e.g. from a previous page load)
       if (reg.waiting) {
+        // If we already tried SKIP_WAITING but the SW is still waiting
+        // (postMessage can silently fail in Safari/WebKit), retry once
+        // then force-unregister as a last resort
+        if (sessionStorage.getItem('sw-skip-waiting')) {
+          sessionStorage.removeItem('sw-skip-waiting');
+          reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+          setTimeout(() => {
+            if (reg.waiting) {
+              reg.unregister().then(() => window.location.reload());
+            }
+          }, 1000);
+          return;
+        }
         _showUpdateBanner(reg.waiting);
       }
 
@@ -2486,8 +2500,8 @@ const App = (() => {
       console.warn('SW registration failed:', err);
     });
 
-    let _updateFallbackTimer = null;
     navigator.serviceWorker.addEventListener('controllerchange', () => {
+      sessionStorage.removeItem('sw-skip-waiting');
       if (_updateFallbackTimer) clearTimeout(_updateFallbackTimer);
       window.location.reload();
     });
@@ -2505,10 +2519,14 @@ const App = (() => {
   }
 
   function _applyUpdate() {
+    dom.updateBanner.classList.remove('visible');
     if (_waitingSW) {
       _waitingSW.postMessage({ type: 'SKIP_WAITING' });
     }
-    // Fallback if controllerchange doesn't fire (common in Safari)
+    // Track that we initiated skip-waiting, so we can detect if it
+    // silently failed after the page reloads (common in Safari/WebKit)
+    sessionStorage.setItem('sw-skip-waiting', '1');
+    // Fallback if controllerchange doesn't fire
     _updateFallbackTimer = setTimeout(() => window.location.reload(), 2000);
   }
 


### PR DESCRIPTION
## Summary
Enhanced the Service Worker update mechanism to better handle cases where `postMessage` silently fails in Safari/WebKit browsers, preventing users from being stuck on outdated versions.

## Key Changes
- **Retry logic for stuck waiting SW**: When a Service Worker is already waiting on page load, the app now checks if a previous skip-waiting attempt was made. If so, it retries the `postMessage` call and falls back to force-unregistering the SW if it's still waiting after 1 second.
- **Session-based skip-waiting tracking**: Added `sessionStorage` flag (`sw-skip-waiting`) to track when a skip-waiting request has been initiated, allowing detection of silent failures across page reloads.
- **Cleanup on successful update**: The flag is cleared when the controller change event fires (indicating successful update) or when retrying on page load.
- **Improved fallback timing**: Moved the `_updateFallbackTimer` variable to module scope and added a 2-second fallback reload in `_applyUpdate()` for cases where `controllerchange` doesn't fire.
- **Banner visibility fix**: The update banner is now hidden immediately when the user clicks "Apply Update".

## Implementation Details
- The retry mechanism only activates if `sessionStorage` indicates a previous skip-waiting attempt, preventing unnecessary force-unregistration on normal page loads.
- The 1-second timeout for the force-unregister fallback gives the SW a reasonable window to respond to the retry before taking drastic action.
- Session storage is used instead of local storage to ensure the flag doesn't persist across browser sessions, limiting the retry logic to the current session only.

https://claude.ai/code/session_01HRHuTpXzU2ruAuVHjZJsTN