### PR TITLE
Fix NY route camera loading for custom IBI 511 routes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -798,53 +798,62 @@ const App = (() => {
   // Primary camera loading path for custom routes. Called immediately with
   // straight-line waypoints, then OSRM geometry re-filters when it arrives.
   async function loadCamerasForGeometry(generation) {
-    const filterPath = currentRouteGeometry || currentWaypoints;
-    if (!filterPath || filterPath.length === 0) return;
-    // Interpolate sparse waypoints so region detection finds intermediate regions
-    const regionPath = filterPath.length < 10 ? _interpolateWaypoints(filterPath, 20) : filterPath;
+    try {
+      const filterPath = currentRouteGeometry || currentWaypoints;
+      if (!filterPath || filterPath.length === 0) return;
+      // Interpolate sparse waypoints so region detection finds intermediate regions
+      const regionPath = filterPath.length < 10 ? _interpolateWaypoints(filterPath, 20) : filterPath;
 
-    // Show cached cameras instantly while region detection hits the network
-    const cachedCameras = API.getCachedImmediate(null);
-    if (cachedCameras && generation === _routeGeneration) {
-      allCameras = cachedCameras;
+      // Show cached cameras instantly while region detection hits the network
+      const cachedCameras = API.getCachedImmediate(null);
+      if (cachedCameras && generation === _routeGeneration) {
+        allCameras = cachedCameras;
+        _lastFilteredIds = '';
+        applyFilters();
+        dom.skeletonList.classList.add('hidden');
+      }
+
+      const neededRegions = await API.getRegionsForRoute(regionPath);
+      if (generation !== _routeGeneration) return; // Route changed while detecting regions
+      if (neededRegions.size === 0) {
+        _lastFilteredIds = '';
+        applyFilters();
+        dom.skeletonList.classList.add('hidden');
+        return;
+      }
+
+      // Force re-render since we have new geometry
+      _lastFilteredIds = '';
+
+      // Fetch cameras for detected regions
+      const freshCameras = [];
+      const debounce = _debouncedApplyFilters(generation, 150);
+      await API.fetchProgressive((region, result) => {
+        if (generation !== _routeGeneration) return; // Stale
+        freshCameras.push(...(result.data || []));
+        allCameras = freshCameras;
+        _lastFilteredIds = ''; // Force re-filter with each new batch
+        debounce.schedule();
+      }, neededRegions);
+      debounce.flush();
+
+      if (generation !== _routeGeneration) return; // Route changed during fetch
+      if (freshCameras.length > 0) {
+        allCameras = freshCameras;
+        _lastFilteredIds = '';
+      }
+      applyFilters();
+
+      dom.skeletonList.classList.add('hidden');
+
+      // Auto-open camera from URL hash
+      requestAnimationFrame(() => _openCameraFromHash());
+    } catch (e) {
+      console.warn('Camera loading failed:', e.message);
       _lastFilteredIds = '';
       applyFilters();
       dom.skeletonList.classList.add('hidden');
     }
-
-    const neededRegions = await API.getRegionsForRoute(regionPath);
-    if (generation !== _routeGeneration) return; // Route changed while detecting regions
-    if (neededRegions.size === 0) {
-      dom.skeletonList.classList.add('hidden');
-      return;
-    }
-
-    // Force re-render since we have new geometry
-    _lastFilteredIds = '';
-
-    // Fetch cameras for detected regions
-    const freshCameras = [];
-    const debounce = _debouncedApplyFilters(generation, 150);
-    await API.fetchProgressive((region, result) => {
-      if (generation !== _routeGeneration) return; // Stale
-      freshCameras.push(...(result.data || []));
-      allCameras = freshCameras;
-      _lastFilteredIds = ''; // Force re-filter with each new batch
-      debounce.schedule();
-    }, neededRegions);
-    debounce.flush();
-
-    if (generation !== _routeGeneration) return; // Route changed during fetch
-    if (freshCameras.length > 0) {
-      allCameras = freshCameras;
-      _lastFilteredIds = '';
-      applyFilters();
-    }
-
-    dom.skeletonList.classList.add('hidden');
-
-    // Auto-open camera from URL hash
-    requestAnimationFrame(() => _openCameraFromHash());
   }
 
   // ── Highlight + scroll helper ───────────────────────────────

--- a/js/app.js
+++ b/js/app.js
@@ -296,17 +296,24 @@ const App = (() => {
             if (city) {
               userLocation.city = city;
               if (fromStop && fromStop.source !== 'geocode' && fromStop.source !== 'geolocation' && !_prefsOrHashSetOrigin) {
-                fromStop = city;
-                const majorCityIds = ['calgary', 'vancouver', 'seattle', 'kamloops', 'kelowna', 'vernon', 'penticton', 'lethbridge', 'bellingham', 'nelson', 'cranbrook'];
-                const majorStops = allStops.filter(s => majorCityIds.includes(s.id) && Cameras.haversine(latitude, longitude, s.lat, s.lon) > 50);
-                if (majorStops.length > 0) {
-                  toStop = Cameras.nearestStop(latitude, longitude, majorStops);
+                // Only auto-set route if user is reasonably close to predefined stops.
+                // If >500km from all stops, skip auto-routing — a cross-continent
+                // route to western Canada is useless. Let the user pick via search.
+                const nearestAny = Cameras.nearestStop(latitude, longitude, allStops);
+                const distToNearest = nearestAny ? Cameras.haversine(latitude, longitude, nearestAny.lat, nearestAny.lon) : Infinity;
+                if (distToNearest <= 500) {
+                  fromStop = city;
+                  const majorCityIds = ['calgary', 'vancouver', 'seattle', 'kamloops', 'kelowna', 'vernon', 'penticton', 'lethbridge', 'bellingham', 'nelson', 'cranbrook'];
+                  const majorStops = allStops.filter(s => majorCityIds.includes(s.id) && Cameras.haversine(latitude, longitude, s.lat, s.lon) > 50);
+                  if (majorStops.length > 0) {
+                    toStop = Cameras.nearestStop(latitude, longitude, majorStops);
+                  }
+                  updateRouteDisplay();
+                  updateRoute();
+                  loadCameras();
+                  updateHash();
+                  savePrefs();
                 }
-                updateRouteDisplay();
-                updateRoute();
-                loadCameras();
-                updateHash();
-                savePrefs();
               } else if (fromStop && fromStop.source === 'geolocation') {
                 fromStop.displayName = city.displayName;
                 updateRouteDisplay();
@@ -1056,9 +1063,10 @@ const App = (() => {
       ? Cameras.filterByCorridor(allCameras, reducedPath, buffer)
       : allCameras;
 
-    // Quick check: skip expensive sort+render if camera set hasn't changed
+    // Quick check: skip expensive sort+render if camera set hasn't changed.
+    // Always re-render when empty so the "No cameras found" state can appear.
     const idSet = cameras.map(c => c.id).join(',');
-    if (idSet === _lastFilteredIds) {
+    if (idSet.length > 0 && idSet === _lastFilteredIds) {
       return; // Same cameras — no sort or DOM work needed
     }
 

--- a/js/app.js
+++ b/js/app.js
@@ -1066,7 +1066,7 @@ const App = (() => {
     // Quick check: skip expensive sort+render if camera set hasn't changed.
     // Always re-render when empty so the "No cameras found" state can appear.
     const idSet = cameras.map(c => c.id).join(',');
-    if (idSet.length > 0 && idSet === _lastFilteredIds) {
+    if (cameras.length > 0 && idSet === _lastFilteredIds) {
       return; // Same cameras — no sort or DOM work needed
     }
 

--- a/js/cameras.js
+++ b/js/cameras.js
@@ -228,12 +228,25 @@ const Cameras = (() => {
       }));
   }
 
+  // Unwrap IBI 511 responses — some deployments return a raw array, others wrap
+  // it in an object under keys like 'body', 'cameras', or 'data'.
+  function unwrapIBI(data) {
+    if (Array.isArray(data)) return data;
+    if (data && typeof data === 'object') {
+      for (const key of ['body', 'cameras', 'data', 'results', 'items']) {
+        if (Array.isArray(data[key])) return data[key];
+      }
+    }
+    return [];
+  }
+
   // Generic IBI 511 normalizer — same format as Alberta but with configurable region code
   function normalizeIBI(data, region) {
-    if (!Array.isArray(data)) return [];
+    const items = unwrapIBI(data);
+    if (items.length === 0) return [];
     const prefix = region.toLowerCase();
     const cameras = [];
-    for (const cam of data) {
+    for (const cam of items) {
       if (!cam.Latitude || !cam.Longitude) continue;
       const views = cam.Views || [];
       for (const view of views) {

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
    sw.js — Service Worker with tiered caching strategies
    ============================================================= */
 
-const CACHE_NAME = 'tripcams-v36';
+const CACHE_NAME = 'tripcams-v37';
 const STATIC_ASSETS = [
   './',
   'index.html',

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
    sw.js — Service Worker with tiered caching strategies
    ============================================================= */
 
-const CACHE_NAME = 'tripcams-v37';
+const CACHE_NAME = 'tripcams-v38';
 const STATIC_ASSETS = [
   './',
   'index.html',


### PR DESCRIPTION
The IBI normalizer only accepted raw JSON arrays, but some 511
deployments (e.g. 511ny.org) wrap camera data in an object. Added
unwrapIBI() to handle common wrapper keys (body, cameras, data,
results, items). Also wrapped loadCamerasForGeometry in try/catch
so the skeleton loader always resolves, and ensured applyFilters
runs even when 0 cameras load so the empty-state message appears.

https://claude.ai/code/session_01BtjQzFN4kXcYARgGppc7m6