### PR TITLE
Refresh geolocation on location button tap with visible feedback

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -697,6 +697,44 @@ button {
   transform: scale(0.9);
 }
 
+.map-center-btn.is-loading {
+  color: var(--accent, #2DB84B);
+  animation: center-btn-pulse 1.1s ease-in-out infinite;
+}
+
+.map-center-btn.is-loading svg {
+  animation: center-btn-spin 1.2s linear infinite;
+}
+
+.map-center-btn.is-error {
+  color: #DC2626;
+  animation: center-btn-shake 0.45s cubic-bezier(.36,.07,.19,.97) both;
+}
+
+@keyframes center-btn-pulse {
+  0%, 100% { box-shadow: var(--shadow-sm); }
+  50% { box-shadow: 0 0 0 4px rgba(45, 184, 75, 0.25), var(--shadow-sm); }
+}
+
+@keyframes center-btn-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes center-btn-shake {
+  10%, 90% { transform: translateX(-1px); }
+  20%, 80% { transform: translateX(2px); }
+  30%, 50%, 70% { transform: translateX(-3px); }
+  40%, 60% { transform: translateX(3px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .map-center-btn.is-loading,
+  .map-center-btn.is-loading svg,
+  .map-center-btn.is-error {
+    animation: none;
+  }
+}
+
 .map-toggle {
   position: absolute;
   top: -52px;

--- a/js/app.js
+++ b/js/app.js
@@ -917,7 +917,7 @@ const App = (() => {
     }
 
     highlightCard(nearestCard);
-    if (nearestCard) TripMap.panTo(userLocation.lat, userLocation.lon);
+    TripMap.panTo(userLocation.lat, userLocation.lon);
   }
 
   // ── URL Hash ─────────────────────────────────────────────────
@@ -1707,21 +1707,55 @@ const App = (() => {
     dom.mapToggle.classList.toggle('active', isSat);
   }
 
+  let _centerMapInFlight = false;
+
   function centerMap() {
-    if (userLocation) {
-      snapToCurrentLocation();
+    if (_centerMapInFlight) return;
+
+    if (!navigator.geolocation) {
+      if (userLocation) { snapToCurrentLocation(); return; }
+      if (currentWaypoints.length > 0) TripMap.fitToRoute(currentWaypoints, { paddingBottom: sheetPeekPadding() });
+      setCenterMapButtonState('error');
       return;
     }
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (pos) => { updateUserLocation(pos); snapToCurrentLocation(); },
-        () => {
+
+    _centerMapInFlight = true;
+    setCenterMapButtonState('loading');
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        _centerMapInFlight = false;
+        updateUserLocation(pos);
+        snapToCurrentLocation();
+        setCenterMapButtonState('idle');
+      },
+      () => {
+        _centerMapInFlight = false;
+        if (userLocation) {
+          snapToCurrentLocation();
+          setCenterMapButtonState('idle');
+        } else {
           if (currentWaypoints.length > 0) TripMap.fitToRoute(currentWaypoints, { paddingBottom: sheetPeekPadding() });
-        },
-        GEO_OPTS
-      );
-    } else if (currentWaypoints.length > 0) {
-      TripMap.fitToRoute(currentWaypoints, { paddingBottom: sheetPeekPadding() });
+          setCenterMapButtonState('error');
+        }
+      },
+      { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
+    );
+  }
+
+  function setCenterMapButtonState(state) {
+    const btn = dom.centerMapBtn;
+    if (!btn) return;
+    btn.classList.remove('is-loading', 'is-error');
+    if (state === 'loading') {
+      btn.classList.add('is-loading');
+      btn.setAttribute('aria-busy', 'true');
+    } else if (state === 'error') {
+      btn.classList.add('is-error');
+      btn.removeAttribute('aria-busy');
+      setTimeout(() => btn.classList.remove('is-error'), 1200);
+    } else {
+      btn.removeAttribute('aria-busy');
     }
   }
 

--- a/sw.js
+++ b/sw.js
@@ -2,7 +2,7 @@
    sw.js — Service Worker with tiered caching strategies
    ============================================================= */
 
-const CACHE_NAME = 'tripcams-v41';
+const CACHE_NAME = 'tripcams-v42';
 const STATIC_ASSETS = [
   './',
   'index.html',


### PR DESCRIPTION
The location button short-circuited on cached userLocation, so tapping it
after leaving the tab open while driving panned to the stale position
(often a visual no-op) with no indication anything happened.

Now the button always requests fresh coords with maximumAge: 0, shows a
pulsing/spinning loading state, and shakes red on error. Also ensures
the map pans even when no nearby camera card is found.