### PR TITLE
Switch custom domain to tripcams.pizza

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-tripcams.zacharyhalvorson.com
+tripcams.pizza

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Live highway cameras along your driving route.**
 
-**Live site: [https://tripcams.zacharyhalvorson.com](https://tripcams.zacharyhalvorson.com)**
+**Live site: [https://tripcams.pizza](https://tripcams.pizza)**
 
 Trip Cams is a progressive web app that shows real-time highway camera feeds along any driving route across North America. Enter any origin and destination — or pick a predefined corridor — and instantly see what road conditions look like between here and there.
 
@@ -119,7 +119,7 @@ Open `ios/TripCams/TripCams.xcodeproj` in Xcode to build and run.
 
 ## Deployment
 
-Pushes to `main` trigger an automatic GitHub Pages deployment via the workflow in `.github/workflows/deploy.yml`. The site is served at `tripcams.zacharyhalvorson.com` via a custom domain configured in the `CNAME` file.
+Pushes to `main` trigger an automatic GitHub Pages deployment via the workflow in `.github/workflows/deploy.yml`. The site is served at `tripcams.pizza` via a custom domain configured in the `CNAME` file.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -11,15 +11,15 @@
   <meta name="description" content="Live highway cameras along your driving route across the US and Canada">
   <meta property="og:title" content="Trip Cams">
   <meta property="og:description" content="Live highway cameras along your driving route across the US and Canada">
-  <meta property="og:image" content="https://tripcams.zacharyhalvorson.com/img/og-image.png">
+  <meta property="og:image" content="https://tripcams.pizza/img/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="1200">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://tripcams.zacharyhalvorson.com">
+  <meta property="og:url" content="https://tripcams.pizza">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Trip Cams">
   <meta name="twitter:description" content="Live highway cameras along your driving route across the US and Canada">
-  <meta name="twitter:image" content="https://tripcams.zacharyhalvorson.com/img/og-image.png">
+  <meta name="twitter:image" content="https://tripcams.pizza/img/og-image.png">
   <title>Trip Cams</title>
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="img/icon.svg" type="image/svg+xml">


### PR DESCRIPTION
## Summary
- Update `CNAME` to `tripcams.pizza` (was `tripcams.zacharyhalvorson.com`)
- Update README live-site link and deployment notes
- Update Open Graph / Twitter image and URL meta tags in `index.html`

DNS at Hover is already pointing the apex at the four GitHub Pages IPs.

## Test plan
- [ ] After merge, GitHub Pages auto-detects the new CNAME and starts serving at https://tripcams.pizza
- [ ] Let's Encrypt cert provisions; toggle "Enforce HTTPS" in repo Settings → Pages
- [ ] Verify https://tripcams.pizza loads the app
- [ ] Verify link previews (OG image) point at the new domain

## Follow-ups
- Set up a redirect from `tripcams.zacharyhalvorson.com` → `tripcams.pizza` (separate change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)